### PR TITLE
add flat menu wagtail in landing page

### DIFF
--- a/django_project/igrac/templates/base.html
+++ b/django_project/igrac/templates/base.html
@@ -472,6 +472,9 @@
 
 {% block footer %}
     <div class="footer-wrapper">
+    <div style="position: fixed; padding: 10px">
+        {% flat_menu 'disclaimer-and-license' show_menu_heading=False %}
+    </div>
         <center>
             <div class="footer-item">{% trans "Brought to you by" %}&nbsp;</div>
             <a class="footer-item" href="https://www.un-igrac.org/" target="_blank"><img src="/static/img/logo-small.png" width="50" alt="logo" style="vertical-align: bottom"/></a>


### PR DESCRIPTION
fix #48 

<img width="1440" alt="Screen Shot 2020-07-23 at 14 39 04" src="https://user-images.githubusercontent.com/26101337/88262470-7a0c4d80-ccf2-11ea-94e9-9af77e3b7a5d.png">

To display the flat menu on the landing page we need to set up the flat menu settings using wagtail admin