### PR TITLE
fix wagtail url make clash with geonode

### DIFF
--- a/django_project/igrac/urls.py
+++ b/django_project/igrac/urls.py
@@ -19,6 +19,6 @@ urlpatterns = [
         name='map_view_slug'),
     url(r'^groundwater/', include('gwml2.urls')),
     url(r'^cms/', include(wagtailadmin_urls)),
-    url(r'^documents/', include(wagtaildocs_urls)),
-    url(r'^pages/', include(wagtail_urls)),
+    url(r'^wagtail/documents/', include(wagtaildocs_urls)),
+    url(r'^wagtail/pages/', include(wagtail_urls)),
 ]


### PR DESCRIPTION
geonode have `/documents` url
but wagtail has too