### PR TITLE
Fix submodules pull for Github Action Checkout

### DIFF
--- a/.github/workflows/build-push-images-latest.yaml
+++ b/.github/workflows/build-push-images-latest.yaml
@@ -2,6 +2,8 @@ name: latest-build
 on:
   workflow_dispatch:
   push:
+    branches: 
+      - develop
     
 jobs:
   docker-builder:

--- a/.github/workflows/build-push-images-latest.yaml
+++ b/.github/workflows/build-push-images-latest.yaml
@@ -10,7 +10,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - run: ls -al django_project/gwml2
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/build-push-images-latest.yaml
+++ b/.github/workflows/build-push-images-latest.yaml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
       - run: ls -al django_project/gwml2
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/build-push-images-latest.yaml
+++ b/.github/workflows/build-push-images-latest.yaml
@@ -2,13 +2,13 @@ name: latest-build
 on:
   workflow_dispatch:
   push:
-    branches:
-      - develop
+    
 jobs:
   docker-builder:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: ls -al django_project/gwml2
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/build-push-images-latest.yaml
+++ b/.github/workflows/build-push-images-latest.yaml
@@ -2,9 +2,8 @@ name: latest-build
 on:
   workflow_dispatch:
   push:
-    branches: 
+    branches:
       - develop
-    
 jobs:
   docker-builder:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-push-images-pr.yaml
+++ b/.github/workflows/build-push-images-pr.yaml
@@ -5,7 +5,7 @@ on:
       - develop
 jobs:
   docker-builder:
-    if: github.event.pull_request.head.repo.fork == 'false'
+    if: github.event.pull_request.base.repo.url == github.event.pull_request.head.repo.url
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-push-images-pr.yaml
+++ b/.github/workflows/build-push-images-pr.yaml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/build-push-images-release.yaml
+++ b/.github/workflows/build-push-images-release.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.tags }}
+          submodules: 'true'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/build-push-images-release.yaml
+++ b/.github/workflows/build-push-images-release.yaml
@@ -47,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/build-push-images-stable.yaml
+++ b/.github/workflows/build-push-images-stable.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx


### PR DESCRIPTION
Will squash commits at the end.
Fix using `submodule: true` options for Github Action Checkout.